### PR TITLE
Merge Calendar change extended hours

### DIFF
--- a/src/zipline/__init__.py
+++ b/src/zipline/__init__.py
@@ -18,7 +18,7 @@ import numpy as np
 
 # This is *not* a place to dump arbitrary classes/modules for convenience,
 # it is a place to expose the public interfaces.
-from zipline.utils.calendar_utils import get_calendar
+from zipline.utils.calendar_utils import get_calendar, get_calendar_for_bundle
 
 from . import data
 from . import finance
@@ -90,6 +90,7 @@ __all__ = [
     "data",
     "finance",
     "get_calendar",
+    "get_calendar_for_bundle",
     "gens",
     "run_algorithm",
     "utils",

--- a/src/zipline/data/bcolz_daily_bars.py
+++ b/src/zipline/data/bcolz_daily_bars.py
@@ -488,7 +488,7 @@ class BcolzDailyBarReader(CurrencyAwareSessionBarReader):
     @lazyval
     def trading_calendar(self):
         if "calendar_name" in self._table.attrs.attrs:
-            return get_calendar(self._table.attrs["calendar_name"])
+            return get_calendar(self._table.attrs["calendar_name"], start_session=self.first_trading_day)
         else:
             return None
 

--- a/src/zipline/data/bcolz_daily_bars.py
+++ b/src/zipline/data/bcolz_daily_bars.py
@@ -441,7 +441,6 @@ class BcolzDailyBarReader(CurrencyAwareSessionBarReader):
             # backwards compatibility with old formats, will remove
             return pd.DatetimeIndex(self._table.attrs["calendar"])
         else:
-            cal = get_calendar(self._table.attrs["calendar_name"])
             start_session_ns = self._table.attrs["start_session_ns"]
 
             start_session = pd.Timestamp(start_session_ns)
@@ -449,6 +448,11 @@ class BcolzDailyBarReader(CurrencyAwareSessionBarReader):
             end_session_ns = self._table.attrs["end_session_ns"]
             end_session = pd.Timestamp(end_session_ns)
 
+            cal = get_calendar(
+                self._table.attrs["calendar_name"],
+                start_session=start_session,
+                end_session=end_session,
+            )
             sessions = cal.sessions_in_range(start_session, end_session)
 
             return sessions

--- a/src/zipline/data/bcolz_minute_bars.py
+++ b/src/zipline/data/bcolz_minute_bars.py
@@ -223,9 +223,13 @@ class BcolzMinuteBarMetadata:
                 minutes_per_day = US_EQUITIES_MINUTES_PER_DAY
 
             if version >= 2:
-                calendar = get_calendar(raw_data["calendar_name"])
                 start_session = pd.Timestamp(raw_data["start_session"])
                 end_session = pd.Timestamp(raw_data["end_session"])
+                calendar = get_calendar(
+                    raw_data["calendar_name"],
+                    start_session=start_session,
+                    end_session=end_session,
+                )
             else:
                 # No calendar info included in older versions, so
                 # default to NYSE.

--- a/src/zipline/data/bundles/core.py
+++ b/src/zipline/data/bundles/core.py
@@ -372,10 +372,12 @@ def _make_bundle_core():
         except KeyError:
             raise UnknownBundle(name)
 
-        calendar = get_calendar(bundle.calendar_name)
-
         start_session = bundle.start_session
         end_session = bundle.end_session
+
+        calendar = get_calendar(
+            bundle.calendar_name, start_session=start_session, end_session=end_session
+        )
 
         if start_session is None or start_session < calendar.first_session:
             start_session = calendar.first_session

--- a/src/zipline/data/data_portal.py
+++ b/src/zipline/data/data_portal.py
@@ -948,7 +948,7 @@ class DataPortal:
             df.iloc[0, assets_with_leading_nan] = np.array(
                 initial_values, dtype=np.float64
             )
-            df.fillna(method="ffill", inplace=True)
+            df.ffill(inplace=True)
 
             # forward-filling will incorrectly produce values after the end of
             # an asset's lifetime, so write NaNs back over the asset's

--- a/src/zipline/utils/calendar_utils.py
+++ b/src/zipline/utils/calendar_utils.py
@@ -47,6 +47,15 @@ def get_calendar(*args, **kwargs):
 
     return calendar
 
+
+def get_calendar_for_bundle(bundle):
+    return get_calendar(
+        bundle.calendar_name,
+        start_session=bundle.start_session,
+        end_session=bundle.end_session,
+    )
+
+
 # get_calendar = compose(partial(get_calendar, side="right"), "XNYS")
 # NOTE Sessions are now timezone-naive (previously UTC).
 # Schedule columns now have timezone set as UTC

--- a/src/zipline/utils/run_algo.py
+++ b/src/zipline/utils/run_algo.py
@@ -14,7 +14,7 @@ except ImportError:
 import logging
 import pandas as pd
 from toolz import concatv
-from zipline.utils.calendar_utils import get_calendar
+from zipline.utils.calendar_utils import get_calendar_for_bundle
 
 from zipline.data import bundles
 from zipline.data.benchmarks import get_benchmark_returns_from_file
@@ -97,7 +97,7 @@ def _run(
     )
 
     if trading_calendar is None:
-        trading_calendar = get_calendar("XNYS")
+        trading_calendar = get_calendar_for_bundle(bundle_data)
 
     # date parameter validation
     if trading_calendar.sessions_distance(start, end) < 1:


### PR DESCRIPTION
Change `get_calendar` to accept `start_session` so that calendars older than 20 years work for any calendar (especially new ones for extended hours), not just the few hardcoded in Zipline.

Add `get_calendar_for_bundle` so that when loading a bundle the `start_session` and `end_session` come from the bundle metadata (instead of the old defaults of either 20 years before today for start or 1990 for the hardcoded ones in Zipline).